### PR TITLE
[pvr.tvh] Use sane defaults for audio stream channel count/sample rate

### DIFF
--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -543,9 +543,9 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
       if (stream.iCodecType == XBMC_CODEC_TYPE_AUDIO)
       {
         stream.iChannels
-          = htsmsg_get_u32_or_default(&f->hmf_msg, "channels", 0);
+          = htsmsg_get_u32_or_default(&f->hmf_msg, "channels", 2);
         stream.iSampleRate
-          = htsmsg_get_u32_or_default(&f->hmf_msg, "rate", 0);
+          = htsmsg_get_u32_or_default(&f->hmf_msg, "rate", 48000);
       }
 
       /* Video */


### PR DESCRIPTION
Same as https://github.com/Jalle19/xbmc-pvr-addons/commit/a7624271283f0973bcad677695faab075044b2df. It marginally speeds up channel switching since the audio decoder won't be restarted when it determines that there's actually more than zero channels in the stream.
