### PR TITLE
Improve error handling

### DIFF
--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -501,7 +501,7 @@ void* CHTSPConnection::Process ( void )
       CLockObject lock(g_mutex);
       host    = g_strHostname;
       port    = g_iPortHTSP;
-      timeout = g_iConnectTimeout;
+      timeout = g_iConnectTimeout * 1000;
     }
 
     /* Create socket (ensure mutex protection) */
@@ -526,13 +526,13 @@ void* CHTSPConnection::Process ( void )
 
     /* Connect */
     tvhtrace("waiting for connection...");
-    if (!m_socket->Open(timeout * 1000))
+    if (!m_socket->Open(timeout))
     {
       /* Unable to connect, inform the user and wait until next retry */
       tvherror("unable to connect to %s:%d", host.c_str(), port);
       XBMC->QueueNotification(QUEUE_ERROR, "Unable to connect to %s:%d", host.c_str(), port);
       
-      Sleep(500); // TODO: Re-try period
+      Sleep(timeout);
       continue;
     }
     tvhdebug("connected");

--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -528,7 +528,10 @@ void* CHTSPConnection::Process ( void )
     tvhtrace("waiting for connection...");
     if (!m_socket->Open(timeout * 1000))
     {
-      tvherror("failed to connect to server");
+      /* Unable to connect, inform the user and wait until next retry */
+      tvherror("unable to connect to %s:%d", host.c_str(), port);
+      XBMC->QueueNotification(QUEUE_ERROR, "Unable to connect to %s:%d", host.c_str(), port);
+      
       Sleep(500); // TODO: Re-try period
       continue;
     }

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -53,6 +53,8 @@ extern "C" {
  * Configuration defines
  */
 #define HTSP_API_VERSION  12
+#define FAST_RECONNECT_TRIES 5
+#define FAST_RECONNECT_INTERVAL 500 // ms
 
 /*
  * Log wrappers

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -33,6 +33,7 @@
 #include "HTSPTypes.h"
 #include <map>
 #include <cstdarg>
+#include <stdexcept>
 
 extern "C" {
 #include <sys/types.h>
@@ -70,6 +71,14 @@ static inline void tvhlog ( ADDON::addon_log_t lvl, const char *fmt, ... )
   va_end(va);
   XBMC->Log(lvl, buf);
 }
+
+/*
+ * Exceptions
+ */
+class AuthException : public std::runtime_error {
+public:
+  AuthException(const std::string &m) : std::runtime_error(m) { }
+};
 
 /*
  * Forward decleration of classes
@@ -155,7 +164,7 @@ private:
   void        Register         ( void );
   bool        ReadMessage      ( void );
   bool        SendHello        ( void );
-  bool        SendAuth         ( const CStdString &u, const CStdString &p );
+  void        SendAuth         ( const CStdString &u, const CStdString &p );
 
   PLATFORM::CTcpSocket               *m_socket;
   PLATFORM::CMutex                    m_mutex;


### PR DESCRIPTION
At the moment if the addon is misconfigured (wrong hostname/port/username/password) it just sits there and the user has to dive into the logs to see what is wrong. This fooled me once at a friend's place where suddenly the channel list was empty (turns out tvheadend had crashed).
