### PR TITLE
[pvr.tvh] don't attempt to get drive space unless we have a connection

### DIFF
--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -354,6 +354,9 @@ const char *GetConnectionString(void)
 
 PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 {
+  if (!tvh->WaitForConnection())
+    return PVR_ERROR_SERVER_TIMEOUT;
+  
   return tvh->GetDriveSpace(iTotal, iUsed);
 }
 


### PR DESCRIPTION
While testing the connection handling I noticed that XBMC queries the disk space from the addon, which naturally fails. Returning PVR_ERROR_SERVER_TIMEOUT when the connection is not ready inhibits this error.
