### PR TITLE
[pvr.tvh] fix that unnumbered channels appears at the top of the list

### DIFF
--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -35,6 +35,8 @@ if ((x) != (y))\
   update = true;\
 }
 
+#define UNNUMBERED_CHANNELNUMBER 1000
+
 using namespace std;
 using namespace ADDON;
 using namespace PLATFORM;
@@ -959,7 +961,10 @@ void CTvheadend::ParseChannelUpdate ( htsmsg_t *msg )
 
   /* Channel number */
   if (!htsmsg_get_u32(msg, "channelNumber", &u32))
+  {
+    u32 = u32 > 0 ? u32 : u32 + UNNUMBERED_CHANNELNUMBER;
     UPDATE(channel.num, u32);
+  }
 
   /* Channel icon */
   if ((str = htsmsg_get_str(msg, "channelIcon")) != NULL)


### PR DESCRIPTION
This adds a magical channel number 10000 for unnumbered channels so that they are placed at the end of the list in XBMC. This is done in the pvr.hts addon and missed here.

IMO this have to be fixed in XBMC, because a valid channel number have to start at 1. But for now we need the same behavior as the old pvr.hts.
