### PR TITLE
[pvr.tvh] implement ParseSubscriptionStatus

### DIFF
--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -644,8 +644,17 @@ void CHTSPDemuxer::ParseSubscriptionSpeed ( htsmsg_t *m )
     tvhtrace("recv speed %d", u32);
 }
 
-void CHTSPDemuxer::ParseSubscriptionStatus ( htsmsg_t *_unused(m) )
+void CHTSPDemuxer::ParseSubscriptionStatus ( htsmsg_t *m )
 {
+  const char *status;
+  status = htsmsg_get_str(m, "status");
+
+  // this field is absent when everything is fine
+  if (status != NULL)
+  {
+    tvhinfo("Bad subscription status: %s", status);
+    XBMC->QueueNotification(QUEUE_INFO, status);
+  }
 }
 
 void CHTSPDemuxer::ParseQueueStatus ( htsmsg_t *_unused(m) )


### PR DESCRIPTION
I was wondering why suddenly almost no channels would start playing. Turns 
out the notification was missing.
