### PR TITLE
Increase timeout when deleting recordings

### DIFF
--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -310,8 +310,11 @@ bool CHTSPConnection::SendMessage ( const char *method, htsmsg_t *msg )
 /*
  * Send a message and wait for response
  */
-htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg )
+htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg, int iResponseTimeout )
 {
+  if (iResponseTimeout == -1)
+    iResponseTimeout = g_iResponseTimeout;
+  
   uint32_t seq;
 
   /* Add Sequence number */
@@ -329,7 +332,7 @@ htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg )
   }
 
   /* Wait for response */
-  msg = resp.Get(m_mutex, g_iResponseTimeout * 1000);
+  msg = resp.Get(m_mutex, iResponseTimeout * 1000);
   m_messages.erase(seq);
   if (!msg)
   {
@@ -343,11 +346,14 @@ htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg )
 /*
  * Send and wait for response
  */
-htsmsg_t *CHTSPConnection::SendAndWait ( const char *method, htsmsg_t *msg )
+htsmsg_t *CHTSPConnection::SendAndWait ( const char *method, htsmsg_t *msg, int iResponseTimeout )
 {
+  if (iResponseTimeout == -1)
+    iResponseTimeout = g_iResponseTimeout;
+  
   if (!WaitForConnection())
     return false;
-  return SendAndWait0(method, msg);
+  return SendAndWait0(method, msg, iResponseTimeout);
 }
 
 bool CHTSPConnection::SendHello ( void )

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -207,14 +207,14 @@ PVR_ERROR CTvheadend::SendDvrDelete ( uint32_t id, const char *method )
   /* Send and Wait */
   if ((m = m_conn.SendAndWait(method, m)) == NULL)
   {
-    tvherror("failed to cancel DVR entry");
+    tvherror("failed to cancel/delete DVR entry");
     return PVR_ERROR_SERVER_ERROR;
   }
 
   /* Check for error */
   if ((str = htsmsg_get_str(m, "error")) != NULL)
   {
-    tvherror("failed to cancel DVR entry [%s]", str);
+    tvherror("failed to cancel/delete DVR entry [%s]", str);
   }
   else if (htsmsg_get_u32(m, "success", &u32))
   {

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -204,8 +204,8 @@ PVR_ERROR CTvheadend::SendDvrDelete ( uint32_t id, const char *method )
   htsmsg_t *m = htsmsg_create_map();
   htsmsg_add_u32(m, "id", id);
 
-  /* Send and Wait */
-  if ((m = m_conn.SendAndWait(method, m)) == NULL)
+  /* Send and wait a bit longer than usual */
+  if ((m = m_conn.SendAndWait(method, m, 30)) == NULL)
   {
     tvherror("failed to cancel/delete DVR entry");
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -133,9 +133,9 @@ public:
   void Disconnect  ( void );
   
   bool      SendMessage0    ( const char *method, htsmsg_t *m );
-  htsmsg_t *SendAndWait0    ( const char *method, htsmsg_t *m );
+  htsmsg_t *SendAndWait0    ( const char *method, htsmsg_t *m, int iResponseTimeout = -1);
   bool      SendMessage     ( const char *method, htsmsg_t *m );
-  htsmsg_t *SendAndWait     ( const char *method, htsmsg_t *m );
+  htsmsg_t *SendAndWait     ( const char *method, htsmsg_t *m, int iResponseTimeout = -1 );
 
   int         GetProtocol      ( void ) { return m_htspVersion; }
 


### PR DESCRIPTION
Quite often (at least for me) I get an error when deleting recordings. This is because the deletion takes quite a while and the default response timeout (which otherwise is very generous at 5 seconds) is not enough. This adds the ability to override the response timeout for individual calls and does it in the SendDvrDelete() method.
