### PR TITLE
[pvr.tvh] return -1 in GetCurrentClientChannel directly

### DIFF
--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -194,11 +194,6 @@ void CHTSPDemuxer::Speed ( int speed )
   SendSpeed();
 }
 
-int CHTSPDemuxer::CurrentId ( void )
-{
-  return -1;
-}
-
 PVR_ERROR CHTSPDemuxer::CurrentStreams ( PVR_STREAM_PROPERTIES *streams )
 {
   CLockObject lock(m_mutex);

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -434,10 +434,6 @@ public:
   {
     return m_dmx.Speed(speed);
   }
-  int          DemuxCurrentId      ( void )
-  {
-    return m_dmx.CurrentId();
-  }
   PVR_ERROR    DemuxCurrentStreams ( PVR_STREAM_PROPERTIES *streams )
   {
     return m_dmx.CurrentStreams(streams);

--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -416,7 +416,7 @@ void SetSpeed(int speed)
 
 int GetCurrentClientChannel(void)
 {
-  return tvh->DemuxCurrentId();
+  return -1; // XBMC doesn't even use this
 }
 
 bool SwitchChannel(const PVR_CHANNEL &channel)


### PR DESCRIPTION
XBMC doesn't even use this API method, it's one of those many things that 
no one has ever bothered to clean up
