### PR TITLE
Detect and use the capabilities reported by the server

### DIFF
--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -167,6 +167,12 @@ const char *CHTSPConnection::GetServerString ( void )
   return str.c_str();
 }
 
+bool CHTSPConnection::HasCapability(const std::string &capability)
+{
+  return std::find(m_capabilities.begin(), m_capabilities.end(), capability) 
+         != m_capabilities.end();
+}
+
 /*
  * Close the connection
  */
@@ -389,14 +395,7 @@ bool CHTSPConnection::SendHello ( void )
     HTSMSG_FOREACH(f, cap)
     {
       if (f->hmf_type == HMF_STR)
-      {
-        if (!strcmp("timeshift", f->hmf_str))
-        {
-        }
-        else if (!strcmp("transcoding", f->hmf_str))
-        {
-        }
-      }
+        m_capabilities.push_back(f->hmf_str);
     }
   }
       

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -156,6 +156,8 @@ public:
   const char *GetServerName    ( void );
   const char *GetServerVersion ( void );
   const char *GetServerString  ( void );
+  
+  bool        HasCapability(const std::string &capability);
 
   bool        IsConnected       ( void ) { return m_ready; }
   bool        WaitForConnection ( void );
@@ -183,6 +185,7 @@ private:
   int                                 m_challengeLen;
 
   std::map<uint32_t,CHTSPResponse*>   m_messages;
+  std::vector<std::string>            m_capabilities;
 };
 
 /*
@@ -393,6 +396,10 @@ public:
   const char *GetServerString  ( void )
   {
     return m_conn.GetServerString();
+  }
+  bool HasCapability(const std::string &capability)
+  {
+      return m_conn.HasCapability(capability);
   }
   bool IsConnected ( void )
   {

--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -384,14 +384,12 @@ PVR_ERROR CallMenuHook
 
 bool CanPauseStream(void)
 {
-  // TODO: dynamic based on server support
-  return true;
+  return tvh->HasCapability("timeshift");
 }
 
 bool CanSeekStream(void)
 {
-  // TODO: dynamic based on server support
-  return true;
+  return tvh->HasCapability("timeshift");
 }
 
 bool OpenLiveStream(const PVR_CHANNEL &channel)


### PR DESCRIPTION
This fixes the current issue where XBMC displays the pause and skip buttons on live streams even when timeshift is not enabled in tvheadend.
