### PR TITLE
Timeshift improvements

### DIFF
--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -172,11 +172,14 @@ bool CHTSPDemuxer::Seek
   }
 
   /* Wait for time */
-  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, 5000) || m_seekTime < 0)
+  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, 5000))
   {
     tvherror("failed to get subscriptionSeek response");
     return false;
   }
+  
+  if (m_seekTime < 0)
+    return false;
 
   /* Store */
   *startpts = TVH_TO_DVD_TIME(m_seekTime);

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -698,13 +698,19 @@ void CHTSPDemuxer::ParseTimeshiftStatus ( htsmsg_t *m )
 {
   uint32_t u32;
   int64_t s64;
-  tvhtrace("timeshiftStatus:");
+  
   if (!htsmsg_get_u32(m, "full", &u32))
-    tvhtrace("  full  : %d", u32);
-  if (!htsmsg_get_s64(m, "start", &s64))
-    tvhtrace("  start : %ld", (long)s64);
-  if (!htsmsg_get_s64(m, "end", &s64))
-    tvhtrace("  end   : %ld", (long)s64);
+    m_timeshiftStatus.full = (bool)u32;
   if (!htsmsg_get_s64(m, "shift", &s64))
-    tvhtrace("  shift : %ld", (long)s64);
+    m_timeshiftStatus.shift = s64;
+  if (!htsmsg_get_s64(m, "start", &s64))
+    m_timeshiftStatus.start = s64;
+  if (!htsmsg_get_s64(m, "end", &s64))
+    m_timeshiftStatus.end = s64;
+  
+  tvhtrace("timeshiftStatus:");
+  tvhtrace("  full  : %d", m_timeshiftStatus.full);
+  tvhtrace("  shift : %ld", (long)m_timeshiftStatus.shift);
+  tvhtrace("  start : %ld", (long)m_timeshiftStatus.start);
+  tvhtrace("  end   : %ld", (long)m_timeshiftStatus.end);
 }

--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -221,6 +221,14 @@ struct SQueueStatus
   }
 };
 
+struct STimeshiftStatus
+{
+  bool    full;
+  int64_t shift;
+  int64_t start;
+  int64_t end;
+};
+
 struct SQuality
 {
   std::string fe_status;

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -196,8 +196,13 @@ public:
   CHTSPDemuxer( CHTSPConnection &conn );
   ~CHTSPDemuxer();
 
-  bool ProcessMessage ( const char *method, htsmsg_t *m );
-  void Connected      ( void );
+  bool   ProcessMessage ( const char *method, htsmsg_t *m );
+  void   Connected      ( void );
+  
+  time_t GetTimeshiftTime()
+  {
+    return (time_t)m_timeshiftStatus.shift;
+  }
 
 private:
   PLATFORM::CMutex                        m_mutex;
@@ -442,6 +447,10 @@ public:
   PVR_ERROR    DemuxCurrentSignal  ( PVR_SIGNAL_STATUS &sig )
   {
     return m_dmx.CurrentSignal(sig);
+  }
+  inline time_t DemuxGetTimeshiftTime()
+  {
+    return m_dmx.GetTimeshiftTime();
   }
 
   /*

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -215,6 +215,7 @@ private:
   PLATFORM::CCondition<volatile int64_t>  m_seekCond;
   SSourceInfo                             m_sourceInfo;
   SQuality                                m_signalInfo;
+  STimeshiftStatus                        m_timeshiftStatus;
   
   void         Close0         ( void );
   void         Abort0         ( void );

--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -637,7 +637,10 @@ void PauseStream(bool _unused(bPaused))
 }
 time_t GetPlayingTime()
 {
-  return 0;
+  // tvheadend reports the number of microseconds the live stream is shifted but 
+  // XBMC expects it to be an absolute UNIX timestamp
+  int seconds = (double) tvh->DemuxGetTimeshiftTime() / 1000000;
+  return (time_t) (time(NULL) - seconds);
 }
 time_t GetBufferTimeStart()
 {


### PR DESCRIPTION
Please read the individual commit messages for the details (not just the first line).

A few notes:
- STimeshiftStatus uses a bool instead of an int since this is not C from 1995
- It seems no one else implements PauseStream(), though I don't see why not
- The SendSpeed() method is a bit funny since it assumes the speed parameter is in XBMC units, not tvheadend units. I think overall it would be best to factor out such differences to client.cpp so sanity and readability can be preserved in the inner layers (like I've done with GetPlayingTime()).
