### PR TITLE
Fix assignment error in SHTSPEvent

### DIFF
--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -278,13 +278,13 @@ struct SSourceInfo
 
 struct SHTSPEvent
 {
-  eHTSPEventType type;
-  uint32_t       idx;
+  eHTSPEventType m_type;
+  uint32_t       m_idx;
 
   SHTSPEvent ( eHTSPEventType type = HTSP_EVENT_NONE, uint32_t idx = 0 )
   {
-    type = type;
-    idx  = idx;
+    m_type = type;
+    m_idx  = idx;
   }
 };
 

--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -44,6 +44,15 @@ typedef enum {
   
 } dvr_action_type_t;
 
+enum eHTSPEventType
+{
+  HTSP_EVENT_NONE = 0,
+  HTSP_EVENT_CHN_UPDATE = 1,
+  HTSP_EVENT_TAG_UPDATE = 2,
+  HTSP_EVENT_EPG_UPDATE = 3,
+  HTSP_EVENT_REC_UPDATE = 4,
+};
+
 struct STag
 {
   bool                  del;
@@ -267,4 +276,16 @@ struct SSourceInfo
   }
 };
 
+struct SHTSPEvent
+{
+  eHTSPEventType type;
+  uint32_t       idx;
 
+  SHTSPEvent ( eHTSPEventType type = HTSP_EVENT_NONE, uint32_t idx = 0 )
+  {
+    type = type;
+    idx  = idx;
+  }
+};
+
+typedef std::vector<SHTSPEvent> SHTSPEventList;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -764,7 +764,7 @@ bool CTvheadend::ProcessMessage ( const char *method, htsmsg_t *msg )
   SHTSPEventList::iterator it;
   for (it = m_events.begin(); it != m_events.end(); it++)
   {
-    switch (it->type)
+    switch (it->m_type)
     {
       case HTSP_EVENT_TAG_UPDATE:
         PVR->TriggerChannelGroupsUpdate();
@@ -777,7 +777,7 @@ bool CTvheadend::ProcessMessage ( const char *method, htsmsg_t *msg )
         PVR->TriggerRecordingUpdate();
         break;
       case HTSP_EVENT_EPG_UPDATE:
-        PVR->TriggerEpgUpdate(it->idx);
+        PVR->TriggerEpgUpdate(it->m_idx);
         break;
       case HTSP_EVENT_NONE:
         break;

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -114,40 +114,6 @@ private:
 };
 
 /*
- * Event trigger
- *
- * Due to potential deadly embrace we defer all XBMC event triggering
- * until we've realeased our mutex
- */
-enum eHTSPEventType
-{
-  HTSP_EVENT_NONE       = 0,
-  HTSP_EVENT_CHN_UPDATE = 1,
-  HTSP_EVENT_TAG_UPDATE = 2,
-  HTSP_EVENT_EPG_UPDATE = 3,
-  HTSP_EVENT_REC_UPDATE = 4,
-};
-
-struct SHTSPEvent
-{
-  eHTSPEventType type;
-  uint32_t       idx;
-
-  SHTSPEvent ( eHTSPEventType type = HTSP_EVENT_NONE, uint32_t idx = 0 )
-  {
-    type = type;
-    idx  = idx;
-  }
-  void Clear ( void )
-  {
-    type = HTSP_EVENT_NONE;
-    idx  = 0;
-  }
-};
-
-typedef std::vector<SHTSPEvent> SHTSPEventList;
-
-/*
  * HTSP Connection registration thread
  */
 class CHTSPRegister


### PR DESCRIPTION
The class members and local variables had the same name, which meant event.type was always undefined.

Edit: s/name/type/
