### PR TITLE
Improve locking when dealing with streams

### DIFF
--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -45,7 +45,7 @@ using namespace ADDON;
 using namespace PLATFORM;
 
 CHTSPDemuxer::CHTSPDemuxer ( CHTSPConnection &conn )
-  : m_conn(conn), m_opened(false), m_started(false), m_chnId(0), m_subId(0),
+  : m_conn(conn), m_opened(false), m_chnId(0), m_subId(0),
     m_speed(1000), m_pktBuffer((size_t)-1)
 {
 }
@@ -101,7 +101,6 @@ bool CHTSPDemuxer::Open ( const PVR_CHANNEL &chn )
   m_speed  = 1000;
 
   /* Open */
-  m_started = false;
   m_opened  = SendSubscribe();
   if (!m_opened)
     SendUnsubscribe();
@@ -200,8 +199,6 @@ void CHTSPDemuxer::Speed ( int speed )
 PVR_ERROR CHTSPDemuxer::CurrentStreams ( PVR_STREAM_PROPERTIES *streams )
 {
   CLockObject lock(m_mutex);
-  if (!m_startCond.Wait(m_mutex, m_started, 5000))
-    return PVR_ERROR_SERVER_ERROR;
   return m_streams.GetProperties(streams) ? PVR_ERROR_NO_ERROR
                                           : PVR_ERROR_SERVER_ERROR; 
 }
@@ -576,10 +573,6 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
 
   /* Source data */
   ParseSourceInfo(htsmsg_get_map(m, "sourceinfo"));
-
-  /* Signal */
-  m_started = true;
-  m_startCond.Broadcast();
 }
 
 void CHTSPDemuxer::ParseSourceInfo ( htsmsg_t *m )

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -76,13 +76,13 @@ void CHTSPDemuxer::Close0 ( void )
 
   /* Clear */
   m_opened  = false;
-  m_started = false;
   Flush();
   Abort0();
 }
 
 void CHTSPDemuxer::Abort0 ( void )
 {
+  CLockObject lock(m_mutex);
   m_streams.Clear();
   m_streamStat.clear();
 }

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -207,11 +207,9 @@ private:
   PLATFORM::CMutex                        m_mutex;
   CHTSPConnection                        &m_conn;
   bool                                    m_opened;
-  bool                                    m_started;
   uint32_t                                m_chnId;
   uint32_t                                m_subId;
   int                                     m_speed;
-  PLATFORM::CCondition<volatile bool>     m_startCond;
   PLATFORM::SyncedBuffer<DemuxPacket*>    m_pktBuffer;
   ADDON::XbmcStreamProperties             m_streams;
   std::map<int,int>                       m_streamStat;


### PR DESCRIPTION
After some log analyzes I noticed that m_streams (the stream vector) and m_streamStat (the stats map) is accessed from multiple threads (at least two). The first commit simply wraps a lock around the members when they are accessed. The second commit extends the lock scope in ParseSubscriptionStart to encompass the whole stream updating process, which means we can get rid of the start condition that was previously only used in the GetCurrentStreams method.

Ideally m_streams (which is a glorified wrapper around a std::vector) should implement the locking itself so that users don't have to bother with it (both pvr.hts and pvr.vdr.vnsi is missing locking) but that's something for after this addon has been (hopefully) merged into the official addon repository.
