### PR TITLE
Refactored subscription handling (fixes four bugs)

### DIFF
--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -262,7 +262,7 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
     m = m_conn.SendAndWait("subscribe", m);
   if (m == NULL)
   {
-    tvhdebug("demux failed to send subscribe");
+    tvherror("demux failed to send subscribe");
     return;
   }
 
@@ -271,7 +271,7 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
   htsmsg_destroy(m);
   if (error)
   {
-    tvhdebug("demux failed to subscribe: %s", error);
+    tvherror("demux failed to subscribe: %s", error);
     return;
   }
 
@@ -295,7 +295,7 @@ void CHTSPDemuxer::SendUnsubscribe ( void )
   tvhdebug("demux unsubcribe from %d", m_subscription.channelId);
   if ((m = m_conn.SendAndWait("unsubscribe", m)) == NULL)
   {
-    tvhdebug("demux failed to send unsubcribe");
+    tvherror("demux failed to send unsubcribe");
     return;
   }
 
@@ -304,7 +304,7 @@ void CHTSPDemuxer::SendUnsubscribe ( void )
   htsmsg_destroy(m);
   if (error)
   {
-    tvhdebug("demux failed to unsubcribe: %s", error);
+    tvherror("demux failed to unsubcribe: %s", error);
     return;
   }
 

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -276,7 +276,7 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
   }
 
   m_subscription.active = true;
-  tvhdebug("demux succesfully subscribed to %d", m_subscription.channelId);
+  tvhdebug("demux successfully subscribed to %d", m_subscription.channelId);
 }
 
 void CHTSPDemuxer::SendUnsubscribe ( void )
@@ -308,7 +308,7 @@ void CHTSPDemuxer::SendUnsubscribe ( void )
     return;
   }
 
-  tvhdebug("demux succesfully unsubscribed %d", m_subscription.channelId);
+  tvhdebug("demux successfully unsubscribed %d", m_subscription.channelId);
 }
 
 void CHTSPDemuxer::SendSpeed ( bool force )

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -287,7 +287,7 @@ void CHTSPDemuxer::SendUnsubscribe ( void )
   htsmsg_add_u32(m, "subscriptionId", m_subId);
 
   /* Send and Wait */
-  tvhdebug("demux unsubcribe from %d", m_subId);
+  tvhdebug("demux unsubcribe from %d", m_chnId);
   if ((m = m_conn.SendAndWait("unsubscribe", m)) == NULL)
   {
     tvhdebug("demux failed to send unsubcribe");
@@ -303,7 +303,7 @@ void CHTSPDemuxer::SendUnsubscribe ( void )
     return;
   }
 
-  tvhdebug("demux succesfully unsubscribed %d", m_subId);
+  tvhdebug("demux succesfully unsubscribed %d", m_chnId);
 }
 
 void CHTSPDemuxer::SendSpeed ( bool force )

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -237,7 +237,7 @@ PVR_ERROR CHTSPDemuxer::CurrentSignal ( PVR_SIGNAL_STATUS &sig )
  * Send Messages
  * *************************************************************************/
 
-bool CHTSPDemuxer::SendSubscribe ( bool force )
+void CHTSPDemuxer::SendSubscribe ( bool force )
 {
   int err;
   htsmsg_t *m;
@@ -263,7 +263,7 @@ bool CHTSPDemuxer::SendSubscribe ( bool force )
   if (m == NULL)
   {
     tvhdebug("demux failed to send subscribe");
-    return false;
+    return;
   }
 
   /* Error */
@@ -272,12 +272,11 @@ bool CHTSPDemuxer::SendSubscribe ( bool force )
   if (err)
   {
     tvhdebug("demux failed to subscribe");
-    return false;
+    return;
   }
 
   m_subscription.active = true;
   tvhdebug("demux succesfully subscribed to %08x", m_subscription.channelId);
-  return true;
 }
 
 void CHTSPDemuxer::SendUnsubscribe ( void )

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -239,7 +239,7 @@ PVR_ERROR CHTSPDemuxer::CurrentSignal ( PVR_SIGNAL_STATUS &sig )
 
 void CHTSPDemuxer::SendSubscribe ( bool force )
 {
-  int err;
+  const char *error;
   htsmsg_t *m;
 
   /* Reset status */
@@ -267,11 +267,11 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
   }
 
   /* Error */
-  err = htsmsg_get_u32_or_default(m, "error", 0);
+  error = htsmsg_get_str(m, "error");
   htsmsg_destroy(m);
-  if (err)
+  if (error)
   {
-    tvhdebug("demux failed to subscribe");
+    tvhdebug("demux failed to subscribe: %s", error);
     return;
   }
 
@@ -281,7 +281,7 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
 
 void CHTSPDemuxer::SendUnsubscribe ( void )
 {
-  int err;
+  const char *error;
   htsmsg_t *m;
 
   /* Build message */
@@ -300,11 +300,11 @@ void CHTSPDemuxer::SendUnsubscribe ( void )
   }
 
   /* Error */
-  err = htsmsg_get_u32_or_default(m, "error", 0);
+  error = htsmsg_get_str(m, "error");
   htsmsg_destroy(m);
-  if (err)
+  if (error)
   {
-    tvhdebug("demux failed to unsubcribe");
+    tvhdebug("demux failed to unsubcribe: %s", error);
     return;
   }
 

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -255,7 +255,7 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
   htsmsg_add_u32(m, "queueDepth",      2000000);
 
   /* Send and Wait for response */
-  tvhdebug("demux subscribe to %08x", m_subscription.channelId);
+  tvhdebug("demux subscribe to %d", m_subscription.channelId);
   if (force)
     m = m_conn.SendAndWait0("subscribe", m);
   else
@@ -276,7 +276,7 @@ void CHTSPDemuxer::SendSubscribe ( bool force )
   }
 
   m_subscription.active = true;
-  tvhdebug("demux succesfully subscribed to %08x", m_subscription.channelId);
+  tvhdebug("demux succesfully subscribed to %d", m_subscription.channelId);
 }
 
 void CHTSPDemuxer::SendUnsubscribe ( void )

--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -293,17 +293,17 @@ typedef std::vector<SHTSPEvent> SHTSPEventList;
 class SSubscription
 {
 public:
-    static uint32_t subscriptionId;
-    uint32_t        channelId;
-    int             speed;
-    bool            active;
+    uint32_t subscriptionId;
+    uint32_t channelId;
+    int      speed;
+    bool     active;
     
     SSubscription()
     {
         speed = 1000;
         active = false;
         
-        // Every instance should have a unique subscription ID
-        ++subscriptionId;
+        static int previousId;
+        subscriptionId = ++previousId;
     }
 };

--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -289,3 +289,21 @@ struct SHTSPEvent
 };
 
 typedef std::vector<SHTSPEvent> SHTSPEventList;
+
+class SSubscription
+{
+public:
+    static uint32_t subscriptionId;
+    uint32_t        channelId;
+    int             speed;
+    bool            active;
+    
+    SSubscription()
+    {
+        speed = 1000;
+        active = false;
+        
+        // Every instance should have a unique subscription ID
+        ++subscriptionId;
+    }
+};

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -231,7 +231,7 @@ private:
   PVR_ERROR    CurrentStreams ( PVR_STREAM_PROPERTIES *streams );
   PVR_ERROR    CurrentSignal  ( PVR_SIGNAL_STATUS &sig );
 
-  bool SendSubscribe   ( bool force = false );
+  void SendSubscribe   ( bool force = false );
   void SendUnsubscribe ( void );
   void SendSpeed       ( bool force = false );
   

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -206,11 +206,7 @@ public:
 private:
   PLATFORM::CMutex                        m_mutex;
   CHTSPConnection                        &m_conn;
-  bool                                    m_opened;
   bool                                    m_started;
-  uint32_t                                m_chnId;
-  uint32_t                                m_subId;
-  int                                     m_speed;
   PLATFORM::CCondition<volatile bool>     m_startCond;
   PLATFORM::SyncedBuffer<DemuxPacket*>    m_pktBuffer;
   ADDON::XbmcStreamProperties             m_streams;
@@ -220,6 +216,7 @@ private:
   SSourceInfo                             m_sourceInfo;
   SQuality                                m_signalInfo;
   STimeshiftStatus                        m_timeshiftStatus;
+  SSubscription                           m_subscription;
   
   void         Close0         ( void );
   void         Abort0         ( void );


### PR DESCRIPTION
This is what I talked about on IRC. I decided it would be better to wrap a subscription as a class (could be a struct too but I thought I'd change it to a class since it has a constructor) so we could get rid of the various member variables that were only used once or twice.

Four bugs are fixed
- the "demux subscribe to" and "demux unsubscribe to" used different values (subscription ID and channel ID)
- the integer formatting used when logging subscribe/unsubscribe messages is confusing since we log a channel number in hexadecimal form
- a subscription is now marked as inactive immediately in SendSubscribe, this way the client won't restart it it gets disconnected while sending the unsubscribe message (which would lead to two subscriptions being sent to the client, one of which's packets would be dropped all the time)
- when a subscription start fails the precise error message was ignored. The error was assumed to be an integer while in fact it's a string containing the error message. That message is now logged.

I haven't tested this yet, just checked that it builds.
