### PR TITLE
[pvr.tvh] don't return all groups when XBMC asks for radio groups

### DIFF
--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -101,7 +101,7 @@ int CTvheadend::GetTagCount ( void )
   return m_tags.size();
 }
 
-PVR_ERROR CTvheadend::GetTags ( ADDON_HANDLE handle, bool _unused(radio) )
+PVR_ERROR CTvheadend::GetTags ( ADDON_HANDLE handle )
 {
   CLockObject lock(m_mutex);
   STags::const_iterator it;

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -301,7 +301,7 @@ public:
   PVR_ERROR GetDriveSpace     ( long long *total, long long *used );
 
   int       GetTagCount       ( void );
-  PVR_ERROR GetTags           ( ADDON_HANDLE handle, bool radio );
+  PVR_ERROR GetTags           ( ADDON_HANDLE handle );
   PVR_ERROR GetTagMembers     ( ADDON_HANDLE handle,
                                 const PVR_CHANNEL_GROUP &group );
 

--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -458,7 +458,11 @@ int GetChannelGroupsAmount(void)
 
 PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
 {
-  return tvh->GetTags(handle, bRadio);
+  // tvheadend doesn't support separate groups for radio and TV
+  if (bRadio)
+    return PVR_ERROR_NO_ERROR;
+  
+  return tvh->GetTags(handle);
 }
 
 PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)


### PR DESCRIPTION
This causes XBMC to remove all TV groups and startup only to recreate them 
a second later when it actually wants to fetch TV groups.

This issue has been reported in various forms on the forums.
