### PR TITLE
[pvr.tvh] don't use the same channel number for all unnumbered channels

### DIFF
--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -1013,12 +1013,12 @@ void CTvheadend::ParseChannelUpdate ( htsmsg_t *msg )
   /* Channel number */
   if (!htsmsg_get_u32(msg, "channelNumber", &u32))
   {
-    if (!u32) u32 = UNNUMBERED_CHANNEL;
+    if (!u32) u32 = GetNextUnnumberedChannelNumber();
     UPDATE(channel.num, u32);
   }
   else if (!channel.num)
   {
-    UPDATE(channel.num, UNNUMBERED_CHANNEL);
+    UPDATE(channel.num, GetNextUnnumberedChannelNumber());
   }
 
   /* Channel icon */
@@ -1320,4 +1320,10 @@ void CTvheadend::ParseEventDelete ( htsmsg_t *msg )
       return;
     }
   }
+}
+
+uint32_t CTvheadend::GetNextUnnumberedChannelNumber()
+{
+  static uint32_t number = UNNUMBERED_CHANNEL;
+  return number++;
 }

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -326,6 +326,8 @@ public:
                                 time_t start, time_t end );
   
 private:
+  uint32_t GetNextUnnumberedChannelNumber();
+  
   PLATFORM::CMutex            m_mutex;
   
   CHTSPConnection             m_conn;


### PR DESCRIPTION
This should hopefully fix some issues with random order that pvagner on the XBMC forums has. It is also in line with what pvr.hts does (although it uses the channel index + 1000, but in the newer tvheadend version channel index is a very large number so it doesn't really make sense to use it as channel number).
