### PR TITLE
Fix deadlock during connect and a bunch of other issues

### DIFF
--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -508,21 +508,16 @@ void* CHTSPConnection::Process ( void )
 
   while (!IsStopped())
   {
-    CStdString host;
-    int port, timeout;
-    {
-      CLockObject lock(g_mutex);
-      host    = g_strHostname;
-      port    = g_iPortHTSP;
-      timeout = g_iConnectTimeout * 1000;
-    }
+    std::string host = m_settings.hostname;
+    int port = m_settings.portHTSP;
+    int timeout = m_settings.connectTimeout;
 
     /* Create socket (ensure mutex protection) */
     {
       CLockObject lock(m_mutex);
       if (m_socket)
         delete m_socket;
-      tvh->Disconnected();
+
       if (!log)
         tvhdebug("connecting to %s:%d", host.c_str(), port);
       else

--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -133,7 +133,7 @@ bool CHTSPConnection::WaitForConnection ( void )
 {
   if (!m_ready) {
     tvhtrace("waiting for registration...");
-    m_regCond.Wait(m_mutex, m_ready, m_settings.connectTimeout);
+    m_regCond.Wait(m_mutex, m_ready, m_settings.connectTimeout * 1000);
   }
   return m_ready;
 }

--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -89,8 +89,8 @@ void *CHTSPRegister::Process ( void )
  * HTSP Connection handler
  */
 
-CHTSPConnection::CHTSPConnection ()
-  : m_socket(NULL), m_regThread(this), m_ready(false), m_seq(0),
+CHTSPConnection::CHTSPConnection (SSettings &settings)
+  : m_settings(settings), m_socket(NULL), m_regThread(this), m_ready(false), m_seq(0),
     m_serverName(""), m_serverVersion(""), m_htspVersion(0),
     m_webRoot(""), m_challenge(NULL), m_challengeLen(0)
 {
@@ -113,15 +113,12 @@ CStdString CHTSPConnection::GetWebURL ( const char *fmt, ... )
   va_list va;
   CStdString auth, url;
 
-  {
-    CLockObject lock(g_mutex);
-    auth = g_strUsername;
-    if (auth != "" && g_strPassword != "")
-      auth += ":" + g_strPassword;
-    if (auth != "")
-      auth += "@";
-    url.Format("http://%s%s:%d", auth.c_str(), g_strHostname.c_str(), g_iPortHTTP);
-  }
+  auth = m_settings.username;
+  if (auth != "" && m_settings.password != "")
+    auth += ":" + m_settings.password;
+  if (auth != "")
+    auth += "@";
+  url.Format("http://%s%s:%d", auth.c_str(), m_settings.hostname.c_str(), m_settings.portHTTP);
 
   CLockObject lock(m_mutex);
   va_start(va, fmt);
@@ -136,7 +133,7 @@ bool CHTSPConnection::WaitForConnection ( void )
 {
   if (!m_ready) {
     tvhtrace("waiting for registration...");
-    m_regCond.Wait(m_mutex, m_ready, g_iConnectTimeout);
+    m_regCond.Wait(m_mutex, m_ready, m_settings.connectTimeout);
   }
   return m_ready;
 }
@@ -160,9 +157,8 @@ const char *CHTSPConnection::GetServerVersion ( void )
 const char *CHTSPConnection::GetServerString ( void )
 {
   static CStdString str;
-  CLockObject lock1(g_mutex);
   CLockObject lock2(m_mutex);
-  str.Format("%s:%d [%s]", g_strHostname.c_str(), g_iPortHTSP,
+  str.Format("%s:%d [%s]", m_settings.hostname.c_str(), m_settings.portHTSP,
              m_ready ? "connected" : "disconnected");
   return str.c_str();
 }
@@ -216,7 +212,7 @@ bool CHTSPConnection::ReadMessage ( void )
   cnt = 0;
   while (cnt < len)
   {
-    r = m_socket->Read((char*)buf + cnt, len - cnt, g_iResponseTimeout * 1000);
+    r = m_socket->Read((char*)buf + cnt, len - cnt, m_settings.responseTimeout * 1000);
     if (r < 0)
     {
       tvherror("failed to read packet (%s)",
@@ -319,7 +315,7 @@ bool CHTSPConnection::SendMessage ( const char *method, htsmsg_t *msg )
 htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg, int iResponseTimeout )
 {
   if (iResponseTimeout == -1)
-    iResponseTimeout = g_iResponseTimeout;
+    iResponseTimeout = m_settings.responseTimeout;
   
   uint32_t seq;
 
@@ -355,7 +351,7 @@ htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg, int
 htsmsg_t *CHTSPConnection::SendAndWait ( const char *method, htsmsg_t *msg, int iResponseTimeout )
 {
   if (iResponseTimeout == -1)
-    iResponseTimeout = g_iResponseTimeout;
+    iResponseTimeout = m_settings.responseTimeout;
   
   if (!WaitForConnection())
     return NULL;
@@ -451,12 +447,6 @@ void CHTSPConnection::SendAuth
  */
 void CHTSPConnection::Register ( void )
 {
-  CStdString user, pass;
-  {
-    CLockObject lock(g_mutex);
-    user = g_strUsername;
-    pass = g_strPassword;
-  }
   {
     CLockObject lock(m_mutex);
 
@@ -472,7 +462,7 @@ void CHTSPConnection::Register ( void )
     
     try
     {
-      SendAuth(user, pass);
+      SendAuth(m_settings.username, m_settings.password);
     }
     catch (AuthException *e)
     {

--- a/addons/pvr.tvh/src/HTSPDemuxer.cpp
+++ b/addons/pvr.tvh/src/HTSPDemuxer.cpp
@@ -177,7 +177,7 @@ bool CHTSPDemuxer::Seek
   htsmsg_destroy(m);
 
   /* Wait for time */
-  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, 5000))
+  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, m_conn.Settings().responseTimeout))
   {
     tvherror("failed to get subscriptionSeek response");
     return false;

--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -53,6 +53,16 @@ enum eHTSPEventType
   HTSP_EVENT_REC_UPDATE = 4,
 };
 
+struct SSettings {
+    std::string username;
+    std::string password;
+    std::string hostname;
+    int portHTSP;
+    int portHTTP;
+    int connectTimeout;
+    int responseTimeout;
+};
+
 struct STag
 {
   bool                  del;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -628,7 +628,7 @@ PVR_ERROR CTvheadend::GetEpg
     htsmsg_add_s64(msg, "maxTime",   end);
 
     /* Send and Wait */
-    if ((msg = m_conn.SendAndWait0("getEvents", msg)) == NULL)
+    if ((msg = m_conn.SendAndWait("getEvents", msg)) == NULL)
     {
       tvherror("failed to request epg");
       return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -667,13 +667,6 @@ PVR_ERROR CTvheadend::GetEpg
  * Connection
  * *************************************************************************/
 
-void CTvheadend::Disconnected ( void )
-{
-  CLockObject lock(m_mutex);
-  m_asyncComplete = false;
-  m_asyncState    = ASYNC_NONE;
-}
-
 bool CTvheadend::Connected ( void )
 {
   htsmsg_t *msg;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -39,9 +39,9 @@ using namespace std;
 using namespace ADDON;
 using namespace PLATFORM;
 
-CTvheadend::CTvheadend()
-  : m_dmx(m_conn), m_vfs(m_conn), m_asyncState(ASYNC_NONE),
-    m_asyncComplete(false)
+CTvheadend::CTvheadend(SSettings settings)
+  : m_settings(settings), m_conn(settings), m_dmx(m_conn), m_vfs(m_conn), 
+    m_asyncState(ASYNC_NONE), m_asyncComplete(false)
 {
 }
 

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -600,7 +600,7 @@ PVR_ERROR CTvheadend::GetEpg
   if (g_bAsyncEpg)
   {
     CLockObject lock(m_mutex);
-    if (!m_asyncCond.Wait(m_mutex, m_asyncComplete, 5000))
+    if (!m_asyncCond.Wait(m_mutex, m_asyncComplete, m_settings.connectTimeout))
       return PVR_ERROR_NO_ERROR;
 
     sit = m_schedules.find(chn.iUniqueId);

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -159,6 +159,7 @@ public:
   bool        WaitForConnection ( void );
 
   inline PLATFORM::CMutex& Mutex ( void ) { return m_mutex; }
+  inline SSettings Settings() { return m_settings; }
   
 private:
   void*       Process          ( void );

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -135,7 +135,7 @@ class CHTSPConnection
   friend class CHTSPRegister;
 
 public:
-  CHTSPConnection();
+  CHTSPConnection(SSettings &settings);
   ~CHTSPConnection();
 
   void Disconnect  ( void );
@@ -167,6 +167,7 @@ private:
   bool        SendHello        ( void );
   void        SendAuth         ( const CStdString &u, const CStdString &p );
 
+  SSettings                           m_settings;
   PLATFORM::CTcpSocket               *m_socket;
   PLATFORM::CMutex                    m_mutex;
   CHTSPRegister                       m_regThread;
@@ -288,7 +289,7 @@ private:
 class CTvheadend
 {
 public:
-  CTvheadend();
+  CTvheadend(SSettings settings);
   ~CTvheadend();
 
   bool Connected      ( void );
@@ -325,6 +326,7 @@ private:
   uint32_t GetNextUnnumberedChannelNumber();
   
   PLATFORM::CMutex            m_mutex;
+  SSettings                   m_settings;
   
   CHTSPConnection             m_conn;
   CHTSPDemuxer                m_dmx;

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -291,7 +291,6 @@ public:
   CTvheadend();
   ~CTvheadend();
 
-  void Disconnected   ( void );
   bool Connected      ( void );
   bool ProcessMessage ( const char *method, htsmsg_t *msg );
 

--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -156,7 +156,18 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
 
   ADDON_ReadSettings();
   
-  tvh = new CTvheadend;
+  // Generate settings struct which we'll pass along. This way there is no need 
+  // to lock the global mutex just to read a setting value
+  SSettings settings;
+  settings.hostname = g_strHostname;
+  settings.username = g_strUsername;
+  settings.password = g_strPassword;
+  settings.portHTSP = g_iPortHTSP;
+  settings.portHTTP = g_iPortHTTP;
+  settings.connectTimeout = g_iConnectTimeout;
+  settings.responseTimeout = g_iResponseTimeout;
+  
+  tvh = new CTvheadend(settings);
 
   /* Wait for connection */
   if (!tvh->WaitForConnection()) {


### PR DESCRIPTION
The plan was to fix the deadlock during startup after 7bacc2200a839b7ede516705e62573a93583d379, but I found some other issues along the way.
- the first commit fixes the deadlock on startup. If the global lock is removed from client.cpp.Create() the whole thing segfaults when Disconnected() is called. The method shouldn't really be needed anyway since Connected() sets the same values and it's called a bit later on.
- I introduced a simple SSettings struct which is passed to CTvheadend and CHTSPConnection. This way these classes don't have to bother with the global lock to read setting values.
- 630ffc1 could theoretically fix something, I don't see why we wouldn't wait for a response here. The rest of the calls to SendWait0 (the version that doesn't wait) are called when the registration process has not yet been completed (like SendHello and SendAuth).
- cf39898 should hopefully fix the issue people have been having with "Connection lost" during startup. This happens from time to time (about once every seven restarts in my observations) and it was we basically waited only 5 milliseconds in WaitForConnection().
- the last commit replaces some magic values with the timeout values

@BtbN mind testing if this fixes anything for you?
@FutureCow you too
