### PR TITLE
Refactor sync handling

### DIFF
--- a/addons/pvr.tvh/Makefile.am
+++ b/addons/pvr.tvh/Makefile.am
@@ -15,6 +15,7 @@ LIBS            = @abs_top_srcdir@/lib/libhts/libhts.la -ldl
 include ../Makefile.include.am
 
 lib_pvr_tvh_addon_la_SOURCES = src/client.cpp \
+                               src/AsyncState.cpp \
                                src/Tvheadend.cpp \
                                src/HTSPConnection.cpp \
                                src/HTSPDemuxer.cpp \

--- a/addons/pvr.tvh/src/AsyncState.cpp
+++ b/addons/pvr.tvh/src/AsyncState.cpp
@@ -1,0 +1,55 @@
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "AsyncState.h"
+#include "client.h"
+
+using namespace PLATFORM;
+
+AsyncState::AsyncState()
+{
+  SetState(ASYNC_NONE);
+}
+
+void AsyncState::SetState(eAsyncState state)
+{
+  CLockObject lock(m_mutex);
+  m_state = state;
+}
+
+void AsyncState::WaitForState(eAsyncState state, int timeoutMs /* = -1*/)
+{
+  // use global response timeout if no specific timeout has been defined
+  if (timeoutMs == -1)
+  {
+    CLockObject lock(g_mutex);
+    timeoutMs = g_iResponseTimeout * 1000;
+  }
+
+  int timeSlept = 0;
+
+  // sleep for WAIT_PERIOD until the timeout is reached or the state changes
+  while (GetState() < state && timeSlept < timeoutMs)
+  {
+    usleep(WAIT_PERIOD_MS * 1000);
+    timeSlept += WAIT_PERIOD_MS;
+  }
+}

--- a/addons/pvr.tvh/src/AsyncState.cpp
+++ b/addons/pvr.tvh/src/AsyncState.cpp
@@ -47,7 +47,7 @@ void AsyncState::WaitForState(eAsyncState state, int timeoutMs /* = -1*/)
   int timeSlept = 0;
 
   // sleep for WAIT_PERIOD until the timeout is reached or the state changes
-  while (GetState() < state && timeSlept < timeoutMs)
+  while (timeSlept < timeoutMs && GetState() < state)
   {
     usleep(WAIT_PERIOD_MS * 1000);
     timeSlept += WAIT_PERIOD_MS;

--- a/addons/pvr.tvh/src/AsyncState.cpp
+++ b/addons/pvr.tvh/src/AsyncState.cpp
@@ -33,10 +33,9 @@ void AsyncState::SetState(eAsyncState state)
 {
   CLockObject lock(m_mutex);
   m_state = state;
-  m_condition.Broadcast();
 }
 
-void AsyncState::WaitForState(eAsyncState state, int timeoutMs /* = -1*/)
+bool AsyncState::WaitForState(eAsyncState state, int timeoutMs /* = -1*/)
 {
   // use global response timeout if no specific timeout has been defined
   if (timeoutMs == -1)
@@ -45,6 +44,8 @@ void AsyncState::WaitForState(eAsyncState state, int timeoutMs /* = -1*/)
     timeoutMs = g_iResponseTimeout * 1000;
   }
   
-  while(GetState() < state)
+  if (GetState() < state)
     m_condition.Wait(m_mutex, timeoutMs);
+  
+  return GetState() >= state;
 }

--- a/addons/pvr.tvh/src/AsyncState.h
+++ b/addons/pvr.tvh/src/AsyncState.h
@@ -1,0 +1,88 @@
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifndef ASYNCSTATE_H
+#define	ASYNCSTATE_H
+
+#include "platform/threads/mutex.h"
+
+/**
+ * Represents the possible states
+ */
+enum eAsyncState
+{
+  ASYNC_NONE = 0,
+  ASYNC_CHN = 1,
+  ASYNC_DVR = 2,
+  ASYNC_EPG = 3,
+  ASYNC_DONE = 4
+};
+
+/**
+ * State tracker for the initial sync process. This class is thread-safe.
+ */
+class AsyncState
+{
+public:
+  AsyncState();
+
+  virtual ~AsyncState()
+  {
+  };
+
+  /**
+   * @return the current state
+   */
+  inline eAsyncState GetState()
+  {
+    PLATFORM::CLockObject lock(m_mutex);
+    return m_state;
+  }
+
+  /**
+   * Changes the current state to "state"
+   * @param state the new state
+   */
+  void SetState(eAsyncState state);
+
+  /**
+   * Waits for the current state to change into "state" or higher
+   * before the timeout is reached
+   * @param state the minimum state desired
+   * @param timeout timeout in milliseconds. Defaults to -1 which means the 
+   * global response timeout will be used.
+   */
+  void WaitForState(eAsyncState state, int timeoutMs = -1);
+
+private:
+
+  /**
+   * The amount of milliseconds to sleep while waiting for a state change
+   */
+  static const int WAIT_PERIOD_MS = 50;
+
+  eAsyncState m_state;
+  PLATFORM::CMutex m_mutex;
+
+};
+
+#endif	/* ASYNCSTATE_H */
+

--- a/addons/pvr.tvh/src/AsyncState.h
+++ b/addons/pvr.tvh/src/AsyncState.h
@@ -69,8 +69,9 @@ public:
    * @param state the minimum state desired
    * @param timeout timeout in milliseconds. Defaults to -1 which means the 
    * global response timeout will be used.
+   * @return whether the state changed or not
    */
-  void WaitForState(eAsyncState state, int timeoutMs = -1);
+  bool WaitForState(eAsyncState state, int timeoutMs = -1);
 
 private:
 

--- a/addons/pvr.tvh/src/AsyncState.h
+++ b/addons/pvr.tvh/src/AsyncState.h
@@ -74,13 +74,9 @@ public:
 
 private:
 
-  /**
-   * The amount of milliseconds to sleep while waiting for a state change
-   */
-  static const int WAIT_PERIOD_MS = 50;
-
   eAsyncState m_state;
   PLATFORM::CMutex m_mutex;
+  PLATFORM::CCondition<bool> m_condition;
 
 };
 

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -105,12 +105,16 @@ CStdString CTvheadend::GetImageURL ( const char *str )
 
 int CTvheadend::GetTagCount ( void )
 {
+  m_asyncState.WaitForState(ASYNC_DVR);
+  
   CLockObject lock(m_mutex);
   return m_tags.size();
 }
 
 PVR_ERROR CTvheadend::GetTags ( ADDON_HANDLE handle )
 {
+  m_asyncState.WaitForState(ASYNC_DVR);
+  
   CLockObject lock(m_mutex);
   STags::const_iterator it;
   for (it = m_tags.begin(); it != m_tags.end(); ++it)
@@ -131,6 +135,8 @@ PVR_ERROR CTvheadend::GetTags ( ADDON_HANDLE handle )
 PVR_ERROR CTvheadend::GetTagMembers
   ( ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group )
 {
+  m_asyncState.WaitForState(ASYNC_DVR);
+  
   CLockObject lock(m_mutex);
   vector<uint32_t>::const_iterator it;
   SChannels::const_iterator cit;
@@ -166,12 +172,16 @@ PVR_ERROR CTvheadend::GetTagMembers
 
 int CTvheadend::GetChannelCount ( void )
 {
+  m_asyncState.WaitForState(ASYNC_DVR);
+  
   CLockObject lock(m_mutex);
   return m_channels.size();
 }
 
 PVR_ERROR CTvheadend::GetChannels ( ADDON_HANDLE handle, bool radio )
 {
+  m_asyncState.WaitForState(ASYNC_DVR);
+  
   CLockObject lock(m_mutex);
   SChannels::const_iterator it;
   for (it = m_channels.begin(); it != m_channels.end(); ++it)
@@ -272,6 +282,8 @@ PVR_ERROR CTvheadend::SendDvrUpdate
 
 int CTvheadend::GetRecordingCount ( void )
 {
+  m_asyncState.WaitForState(ASYNC_EPG);
+  
   int ret = 0;
   SRecordings::const_iterator rit;
   CLockObject lock(m_mutex);
@@ -283,6 +295,8 @@ int CTvheadend::GetRecordingCount ( void )
 
 PVR_ERROR CTvheadend::GetRecordings ( ADDON_HANDLE handle )
 {
+  m_asyncState.WaitForState(ASYNC_EPG);
+  
   CLockObject lock(m_mutex);
   SRecordings::const_iterator rit;
   SChannels::const_iterator cit;
@@ -441,6 +455,8 @@ PVR_ERROR CTvheadend::RenameRecording ( const PVR_RECORDING &rec )
 
 int CTvheadend::GetTimerCount ( void )
 {
+  m_asyncState.WaitForState(ASYNC_EPG);
+  
   int ret = 0;
   SRecordings::const_iterator rit;
   CLockObject lock(m_mutex);
@@ -452,6 +468,8 @@ int CTvheadend::GetTimerCount ( void )
 
 PVR_ERROR CTvheadend::GetTimers ( ADDON_HANDLE handle )
 {
+  m_asyncState.WaitForState(ASYNC_EPG);
+  
   CLockObject lock(m_mutex);
   SRecordings::const_iterator rit;
 

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -31,6 +31,7 @@
 #include "libXBMC_addon.h"
 #include "CircBuffer.h"
 #include "HTSPTypes.h"
+#include "AsyncState.h"
 #include <map>
 #include <queue>
 #include <cstdarg>
@@ -381,15 +382,7 @@ private:
 
   SHTSPEventList              m_events;
 
-  enum {
-    ASYNC_NONE = 0,
-    ASYNC_CHN  = 1,
-    ASYNC_DVR  = 2,
-    ASYNC_EPG  = 3,
-    ASYNC_DONE = 4
-  }                           m_asyncState;
-  bool                        m_asyncComplete;
-  PLATFORM::CCondition<bool>  m_asyncCond;
+  AsyncState                  m_asyncState;
   
   CStdString  GetImageURL     ( const char *str );
 

--- a/lib/platform/threads/mutex.h
+++ b/lib/platform/threads/mutex.h
@@ -251,6 +251,11 @@ namespace PLATFORM
           m_condition.Wait(mutex.m_mutex);
         return true;
       }
+      
+      inline bool Wait(CMutex &mutex, uint32_t iTimeout)
+      {
+        return m_condition.Wait(mutex.m_mutex, iTimeout);
+      }
 
       inline bool Wait(CMutex &mutex, _Predicate &predicate, uint32_t iTimeout)
       {


### PR DESCRIPTION
This factors out the state tracking to a separate class. The class performs locking internally so the caller doesn't need to bother with it.

The second commit adds calls to WaitForState() to the various getters XBMC calls during initialization. This default timeout is taken from the response timeout setting. This should prevent XBMC from fetching channels (and other things) before the client has actually loaded them all, which would otherwise cause missing channels.

@adamsutton the implementation of WaitForState() isn't exactly pretty but it seems to do the job. I have not tested this on Windows yet, could be that we need to include a platform header which defines usleep().
