### PR TITLE
Remove unused event fields

### DIFF
--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -171,7 +171,6 @@ struct SEvent
   uint32_t    episode;
   uint32_t    part;
   std::string title;
-  std::string subtitle;
   std::string desc;
   std::string summary;
   std::string image;
@@ -193,7 +192,6 @@ struct SEvent
     episode = 0;
     part    = 0;
     title.clear();
-    subtitle.clear();
     desc.clear();
     summary.clear();
     image.clear();

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -1310,7 +1310,6 @@ void CTvheadend::ParseEventUpdate ( htsmsg_t *msg )
 {
   bool update = false;
   SEvent tmp;
-  tmp.Clear();
 
   /* Parse */
   if (!ParseEvent(msg, tmp))

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -1290,8 +1290,6 @@ bool CTvheadend::ParseEvent ( htsmsg_t *msg, SEvent &evt )
     evt.summary  = str;
   if ((str = htsmsg_get_str(msg, "description")) != NULL)
     evt.desc     = str;
-  if ((str = htsmsg_get_str(msg, "subtitle")) != NULL)
-    evt.subtitle = str;
   if ((str = htsmsg_get_str(msg, "image")) != NULL)
     evt.image   = str;
   if (!htsmsg_get_u32(msg, "nextEventId", &u32))
@@ -1332,7 +1330,6 @@ void CTvheadend::ParseEventUpdate ( htsmsg_t *msg )
   UPDATE(evt.channel,  tmp.channel);
   UPDATE(evt.summary,  tmp.summary);
   UPDATE(evt.desc,     tmp.desc);
-  UPDATE(evt.subtitle, tmp.subtitle);
   UPDATE(evt.image,    tmp.image);
   UPDATE(evt.next,     tmp.next);
   UPDATE(evt.content,  tmp.content);


### PR DESCRIPTION
@adamsutton the first two commits are valid in either case, but could you comment on the last one? Does it make sense to remove these fields from a performance point of view?
