### PR TITLE
[pvr.tvh] compare tags before triggering an update

### DIFF
--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -70,6 +70,17 @@ struct STag
     icon.clear();
     channels.clear();
   }
+
+  inline bool operator==(const STag &right)
+  {
+    return id == right.id && name == right.name &&
+           icon == right.icon && channels == right.channels;
+  }
+
+  inline bool operator!=(const STag &right)
+  {
+    return !(*this == right);
+  }
 };
 
 struct SChannel


### PR DESCRIPTION
This makes it possible to compare two tag structs. Previously after a connection loss we'd tell XBMC to update all of its tags and members unnecessarily, this should fix that since it properly checks whether a tag has changed.
