### PR TITLE
Bunch of minor fixes and improvements

### DIFF
--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -304,16 +304,6 @@ bool CHTSPConnection::SendMessage0 ( const char *method, htsmsg_t *msg )
 }
 
 /*
- * Send a message (if connection is not up wait)
- */
-bool CHTSPConnection::SendMessage ( const char *method, htsmsg_t *msg )
-{
-  if (!WaitForConnection())
-    return false;
-  return SendMessage0(method, msg);
-}
-
-/*
  * Send a message and wait for response
  */
 htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg, int iResponseTimeout )

--- a/addons/pvr.tvh/src/HTSPVFS.cpp
+++ b/addons/pvr.tvh/src/HTSPVFS.cpp
@@ -60,18 +60,6 @@ void CHTSPVFS::Connected ( void )
   }
 }
 
-bool CHTSPVFS::ProcessMessage
-  ( const char *_unused(method), htsmsg_t *_unused(m) )
-{
-  return false;
-}
-
-void CHTSPVFS::Flush ( void )
-{
-  m_buffer.reset();
-  m_offset = 0;
-}
-
 /* **************************************************************************
  * VFS API
  * *************************************************************************/
@@ -104,7 +92,8 @@ void CHTSPVFS::Close ( void )
   if (m_fileId != 0)
     SendFileClose();
 
-  Flush();
+  m_buffer.reset();
+  m_offset = 0;
   m_fileId = 0;
   m_path   = "";
 }

--- a/addons/pvr.tvh/src/HTSPVFS.cpp
+++ b/addons/pvr.tvh/src/HTSPVFS.cpp
@@ -87,8 +87,6 @@ bool CHTSPVFS::Open ( const PVR_RECORDING &rec )
 
 void CHTSPVFS::Close ( void )
 {
-  CLockObject lock(m_conn.Mutex());
-
   if (m_fileId != 0)
     SendFileClose();
 

--- a/addons/pvr.tvh/src/HTSPVFS.cpp
+++ b/addons/pvr.tvh/src/HTSPVFS.cpp
@@ -101,7 +101,6 @@ void CHTSPVFS::Close ( void )
 int CHTSPVFS::Read ( unsigned char *buf, unsigned int len )
 {
   ssize_t ret;
-  CLockObject lock(m_conn.Mutex());
 
   /* Not opened */
   if (!m_fileId)
@@ -123,7 +122,11 @@ int CHTSPVFS::Read ( unsigned char *buf, unsigned int len )
              m_fileId, (long long)m_buffer.free());
     
     /* Send */
-    m = m_conn.SendAndWait("fileRead", m);
+    {
+      CLockObject lock(m_conn.Mutex());
+      m = m_conn.SendAndWait("fileRead", m);
+    }
+      
     if (m == NULL)
     {
       tvherror("vfs fileRead failed to send");

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -1238,9 +1238,11 @@ void CTvheadend::ParseRecordingUpdate ( htsmsg_t *msg )
   /* Update */
   if (update)
   {
+    std::string error = rec.error.empty() ? "none" : rec.error;
+    
     tvhdebug("recording id:%d, state:%s, title:%s, desc:%s, error:%s",
              rec.id, state, rec.title.c_str(), rec.description.c_str(),
-             rec.error.c_str());
+             error.c_str());
 
     if (m_asyncState.GetState() > ASYNC_DVR)
     {

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -265,7 +265,12 @@ PVR_ERROR CTvheadend::SendDvrUpdate
     htsmsg_add_s64(m, "stop",  stop);
 
   /* Send and Wait */
-  if ((m = m_conn.SendAndWait("updateDvrEntry", m)) == NULL)
+  {
+    CLockObject lock(m_conn.Mutex());
+    m = m_conn.SendAndWait("updateDvrEntry", m);
+  }
+    
+  if (m == NULL)
   {
     tvherror("failed to update DVR entry");
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -373,7 +373,7 @@ PVR_ERROR CTvheadend::GetRecordingEdl
   if (m_conn.GetProtocol() < 12)
     return PVR_ERROR_NOT_IMPLEMENTED;
   
-  CLockObject lock(m_mutex);
+  CLockObject lock(m_conn.Mutex());
   htsmsg_t *list;
   htsmsg_field_t *f;
   int idx;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -391,12 +391,12 @@ PVR_ERROR CTvheadend::GetRecordingEdl
     return PVR_ERROR_SERVER_ERROR;
   }
 
-  /* Validate */
+  /* Check if we got any cut points */
   if (!(list = htsmsg_get_list(m, "cutpoints")))
   {
-    tvherror("malformed getDvrCutpoints response");
+    tvhinfo("no cut points available from dvr entry %s", rec.strRecordingId);
     htsmsg_destroy(m);
-    return PVR_ERROR_FAILED;
+    return PVR_ERROR_NO_ERROR;
   }
 
   /* Process */

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -747,10 +747,6 @@ bool CTvheadend::ProcessMessage ( const char *method, htsmsg_t *msg )
   if (m_dmx.ProcessMessage(method, msg))
     return true;
 
-  /* VFS */
-  if (m_vfs.ProcessMessage(method, msg))
-    return true;
-
   /* Store */
   m_queue.Push(CHTSPMessage(method, msg));
   return false;

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -183,7 +183,6 @@ public:
   
   bool      SendMessage0    ( const char *method, htsmsg_t *m );
   htsmsg_t *SendAndWait0    ( const char *method, htsmsg_t *m, int iResponseTimeout = -1);
-  bool      SendMessage     ( const char *method, htsmsg_t *m );
   htsmsg_t *SendAndWait     ( const char *method, htsmsg_t *m, int iResponseTimeout = -1 );
 
   inline int  GetProtocol      ( void ) const { return m_htspVersion; }
@@ -299,7 +298,6 @@ public:
   CHTSPVFS ( CHTSPConnection &conn );
   ~CHTSPVFS ();
 
-  bool ProcessMessage ( const char *method, htsmsg_t *m );
   void Connected    ( void );
 
 private:
@@ -308,8 +306,6 @@ private:
   uint32_t        m_fileId;
   CCircBuffer     m_buffer;
   int64_t         m_offset;
-
-  void      Flush  ( void );
 
   bool      Open   ( const PVR_RECORDING &rec );
   void      Close  ( void );

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -530,6 +530,7 @@ public:
   }
   inline void         VfsClose            ( void )
   {
+    PLATFORM::CLockObject lock(m_conn.Mutex());
     m_vfs.Close();
   }
   inline int          VfsRead             ( unsigned char *buf, unsigned int len )


### PR DESCRIPTION
- removed some unused methods
- fix two issues with cut points, may or may not actually fix anything
- reduce lock scope in some methods to avoid stalling the connection for too long
- fix some recursive locking in CHTSPVFS
- made sure the connection mutex is always locked if SendAndWait() is called
- log "error:none" instead of "error:" when retrieving recordings, at least one user (myself not including) has been fooled into thinking something's wrong
