### PR TITLE
[pvr.tvh] remove SChannel.now and SChannel.next, XBMC doesn't use

### DIFF
--- a/addons/pvr.tvh/src/HTSPTypes.h
+++ b/addons/pvr.tvh/src/HTSPTypes.h
@@ -87,8 +87,6 @@ struct SChannel
 {
   bool             del;
   uint32_t         id;
-  uint32_t         now;
-  uint32_t         next;
   uint32_t         num;
   bool             radio;
   uint32_t         caid;
@@ -100,8 +98,6 @@ struct SChannel
   {
     del   = false;
     id    = 0;
-    now   = 0;
-    next  = 0;
     num   = 0;
     radio = false;
     caid  = 0;

--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -1098,12 +1098,6 @@ void CTvheadend::ParseChannelUpdate ( htsmsg_t *msg )
     UPDATE(channel.icon, url);
   }
 
-  /* EPG info */
-  if (!htsmsg_get_u32(msg, "eventId", &u32))
-    UPDATE(channel.now,  u32);
-  if (!htsmsg_get_u32(msg, "nextEventId", &u32))
-    UPDATE(channel.next, u32);
-
   /* Services */
   if ((list = htsmsg_get_list(msg, "services")) != NULL)
   {


### PR DESCRIPTION
them and we needlessy trigger a lot of channel updates whenever
these values change
