### PR TITLE
Fix playback of large recorded mkv files.

### DIFF
--- a/addons/pvr.tvh/src/HTSPVFS.cpp
+++ b/addons/pvr.tvh/src/HTSPVFS.cpp
@@ -251,7 +251,7 @@ void CHTSPVFS::SendFileClose ( void )
   // Note: ignore the return;
 }
 
-ssize_t CHTSPVFS::SendFileSeek ( int64_t pos, int whence, bool force )
+long long CHTSPVFS::SendFileSeek ( int64_t pos, int whence, bool force )
 {
   htsmsg_t *m;
   int64_t ret = -1;
@@ -294,5 +294,5 @@ ssize_t CHTSPVFS::SendFileSeek ( int64_t pos, int whence, bool force )
   else
     tvherror("vfs fileSeek failed");
 
-  return (ssize_t)ret;
+  return ret;
 }

--- a/addons/pvr.tvh/src/Tvheadend.h
+++ b/addons/pvr.tvh/src/Tvheadend.h
@@ -314,7 +314,7 @@ private:
 
   bool      SendFileOpen  ( bool force = false );
   void      SendFileClose ( void );
-  ssize_t   SendFileSeek  ( int64_t pos, int whence, bool force = false );
+  long long SendFileSeek  ( int64_t pos, int whence, bool force = false );
 };
 
 /*


### PR DESCRIPTION
CHTSPVFS::SendFileSeek() was returning an error due to 32-bit ssize_t overflow which caused matroska header parsing to fail.
