### PR TITLE
[pvr.tvh] Added new PVR API function getBackendHostname.

### DIFF
--- a/addons/pvr.tvh/addon/addon.xml.in
+++ b/addons/pvr.tvh/addon/addon.xml.in
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.tvh"
-  version="0.9.8"
+  version="0.9.9"
   name="Tvheadend Client"
   provider-name="Adam Sutton">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.2"/>
+    <import addon="xbmc.pvr" version="1.9.3"/>
     <import addon="xbmc.codec" version="1.0.0"/>
   </requires>
   <extension

--- a/addons/pvr.tvh/addon/changelog.txt
+++ b/addons/pvr.tvh/addon/changelog.txt
@@ -1,3 +1,6 @@
+0.9.9
+- added getBackendHostname function
+
 0.9.8
  - version bump for Kodi rebranding
  - cleanup of the response handling code (@ksooo)

--- a/addons/pvr.tvh/src/client.cpp
+++ b/addons/pvr.tvh/src/client.cpp
@@ -331,6 +331,11 @@ const char *GetConnectionString(void)
   return tvh->GetServerString();
 }
 
+const char *GetBackendHostname(void)
+{
+  return g_strHostname.c_str();
+}
+
 PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 {
   return tvh->GetDriveSpace(iTotal, iUsed);


### PR DESCRIPTION
Added new PVR API function getBackendHostname. 

Please refer to https://github.com/opdenkamp/xbmc-pvr-addons/pull/372  and https://github.com/xbmc/xbmc/pull/4342 for details
