### PR TITLE
[pvr.tvh] Added support for state "missed" to ParseRecordingUpdate().

### DIFF
--- a/addons/pvr.tvh/src/Tvheadend.cpp
+++ b/addons/pvr.tvh/src/Tvheadend.cpp
@@ -1351,6 +1351,10 @@ void CTvheadend::ParseRecordingUpdate ( htsmsg_t *msg )
   {
     UPDATE(rec.state, PVR_TIMER_STATE_COMPLETED);
   }
+  else if (strstr(state, "missed") != NULL)
+  {
+    UPDATE(rec.state, PVR_TIMER_STATE_ERROR);
+  }
   else if (strstr(state, "invalid")   != NULL)
   {
     UPDATE(rec.state, PVR_TIMER_STATE_ERROR);


### PR DESCRIPTION
tvh sets the state to "missed" under some circumstances. => https://github.com/tvheadend/tvheadend/blob/master/src/htsp_server.c#L706, but support for this state was missing in pvr.tvh. 

This led to a situation where my XBMC was thinking it would do an "endless" recording, because it never received an update for the started recording. Reason: pvr.tvh did not call TriggerTimerUpdate() for the case were noting changed in the pvrreocrdingupdate event but the "state" (went  to "missed" => variable update was false => no call to TriggerTimerUpdate).

BTW: pvr.hts also does not support state "missed", but is not affected by this bug, as it always calls TriggerTimerUpdate, regardless of a real change in data. :-/
