### PR TITLE
[pvr.tvh] Fix doublefree in HTSPConnection::ReadMessage.

### DIFF
--- a/addons/pvr.tvh/src/HTSPConnection.cpp
+++ b/addons/pvr.tvh/src/HTSPConnection.cpp
@@ -231,7 +231,7 @@ bool CHTSPConnection::ReadMessage ( void )
   /* Deserialize */
   if (!(msg = htsmsg_binary_deserialize(buf, len, buf)))
   {
-    free(buf);
+    /* Do not free buf here. Already done by htsmsg_binary_deserialize. */
     tvherror("failed to decode message");
     return false;
   }


### PR DESCRIPTION
If htsmsg_binary_deserialize fails it frees buf by itself. See:
https://github.com/adamsutton/xbmc-pvr-addons/blob/master/lib/libhts/htsmsg_binary.c#L127
+
https://github.com/adamsutton/xbmc-pvr-addons/blob/master/lib/libhts/htsmsg_binary.c#L130
+
https://github.com/adamsutton/xbmc-pvr-addons/blob/master/lib/libhts/htsmsg.c#L181

I ran into this SIGABRT from time to time during Kodi startup. 

Reason for not working unmarshalling is subject for another investigation. I guess, it has something to do with tvh not yet available while pvr.tvh already calling it.
